### PR TITLE
Feature: alpha and/or numeric in alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,22 @@ Grab the latest binary from [the releases page](https://github.com/kamaln7/klein
 klein uses CLI options for config.
 
 
-| option               | description                              | default                  |
-| -------------------- | ---------------------------------------- | ------------------------ |
-| `-key string`        | `key` for the Static Key auth module. Uses Unauthe if left blank. |                          |
-| `-alphanumeric.length int`        | Alias length for the Alphanumeric alias module. |                          |
-| `-memorable.length int`        | Alias length for the Memorable alias module. |                          |
-| `-listenAddr string` | The network address to listen on.        | `127.0.0.1:5556`         |
-| `-file.path string`       | Path to the storage directory for the File storage module. |                          |
-| `-bolt.path string`       | Path to the bolt database for the Bolt storage module. |                          |
-| `-redis.address string`       | Address:Port for the Redis storage module. |                          |
-| `-redis.auth string`       | Authentication string for the Redis storage module. |                          |
-| `-redis.db int`       | Database ID for the Redis storage module. | `0` |
-| `-root string`       | The URL to redirect to when the `/` path is accessed. Returns a `404 Not Found` error if left blank. |                          |
-| `-template string`   | Path to 404 document to serve in case a 404 error occurs. Returns a plaintext "404 not found" if left blank. |                          |
-| `-url string`        | Base URL to the hosted instance of the klein. | `http://listenAddr/` |
+| option                     | description                                                                                                  | default              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `-key string`              | `key` for the Static Key auth module. Uses Unauthe if left blank.                                            |                      |
+| `-alphanumeric.length int` | Alias length for the Alphanumeric alias module.                                                              |                      |
+| `-alphanumeric.alpha bool` | Include English alphabet characters in the Alphanumeric module aliases.                                      | `true`               |
+| `-alphanumeric.num bool`   | Include numbers in the Alphanumeric module aliases.                                                          | `true`               |
+| `-memorable.length int`    | Alias length for the Memorable alias module.                                                                 |                      |
+| `-listenAddr string`       | The network address to listen on.                                                                            | `127.0.0.1:5556`     |
+| `-file.path string`        | Path to the storage directory for the File storage module.                                                   |                      |
+| `-bolt.path string`        | Path to the bolt database for the Bolt storage module.                                                       |                      |
+| `-redis.address string`    | Address:Port for the Redis storage module.                                                                   |                      |
+| `-redis.auth string`       | Authentication string for the Redis storage module.                                                          |                      |
+| `-redis.db int`            | Database ID for the Redis storage module.                                                                    | `0`                  |
+| `-root string`             | The URL to redirect to when the `/` path is accessed. Returns a `404 Not Found` error if left blank.         |                      |
+| `-template string`         | Path to 404 document to serve in case a 404 error occurs. Returns a plaintext "404 not found" if left blank. |                      |
+| `-url string`              | Base URL to the hosted instance of the klein.                                                                | `http://listenAddr/` |
 
 You must specify one storage provider (`file.path`/`bolt.path`/`redis.address`) and one alias provider (`alphanumeric.length`/`memorable.length`).
 

--- a/alias/alphanumeric/main.go
+++ b/alias/alphanumeric/main.go
@@ -1,6 +1,7 @@
 package alphanumeric
 
 import (
+	"errors"
 	"math/rand"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 // Provider implements an alias generator
 type Provider struct {
 	Config *Config
+	runes  []rune
 }
 
 // ensure that the storage.Provider interface is implemented
@@ -18,25 +20,51 @@ var _ alias.Provider = new(Provider)
 // Config contains the configuration for the file storage
 type Config struct {
 	Length     int
+	Alpha      bool
+	Num        bool
 	randSource *rand.Rand
 }
 
-var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+var alpha = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+var num = []rune("0123456789")
 
 // New initializes the alias generator and returns a new instance
-func New(c *Config) *Provider {
+func New(c *Config) (*Provider, error) {
 	c.randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	return &Provider{
+	provider := &Provider{
 		Config: c,
 	}
+	err := provider.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return provider, nil
+}
+
+// Init sets up the alphanumeric alias
+func (p *Provider) Init() error {
+	var runes []rune
+	switch {
+	case p.Config.Alpha == true:
+		runes = append(runes, alpha...)
+		fallthrough
+	case p.Config.Num == true:
+		runes = append(runes, num...)
+	default:
+		return errors.New("please specify at least alpha or numeric!")
+	}
+
+	p.runes = runes
+	return nil
 }
 
 // Generate returns a random alias
 func (p *Provider) Generate() string {
 	b := make([]rune, p.Config.Length)
 	for i := range b {
-		b[i] = runes[p.Config.randSource.Intn(len(runes))]
+		b[i] = p.runes[p.Config.randSource.Intn(len(p.runes))]
 	}
 
 	return string(b)

--- a/cmd/klein/main.go
+++ b/cmd/klein/main.go
@@ -22,7 +22,9 @@ import (
 )
 
 var (
-	alphanumericlength = flag.Int("alphanumeric.length", -1, "alphanumeric code length")
+	alphanumericLength = flag.Int("alphanumeric.length", -1, "alphanumeric code length")
+	alphanumericAlpha  = flag.Bool("alphanumeric.alpha", true, "use letters in code")
+	alphanumericNum    = flag.Bool("alphanumeric.num", true, "use numbers in code")
 	memorablelength    = flag.Int("memorable.length", -1, "memorable word count")
 	key                = flag.String("key", "", "upload API Key")
 	root               = flag.String("root", "", "root redirect")
@@ -73,7 +75,7 @@ func main() {
 		"cannot use both alphanumeric and memorable alias providers",
 		"please pass one alias provider",
 		-1,
-		*alphanumericlength, *memorablelength,
+		*alphanumericLength, *memorablelength,
 	)
 
 	// 404
@@ -133,10 +135,17 @@ func main() {
 
 	var aliasProvider alias.Provider
 	switch {
-	case *alphanumericlength != -1:
-		aliasProvider = alphanumeric.New(&alphanumeric.Config{
-			Length: *alphanumericlength,
+	case *alphanumericLength != -1:
+		var err error
+		aliasProvider, err = alphanumeric.New(&alphanumeric.Config{
+			Length: *alphanumericLength,
+			Alpha:  *alphanumericAlpha,
+			Num:    *alphanumericNum,
 		})
+
+		if err != nil {
+			logger.Fatalf("could not select alphanumeric alias: %s\n", err.Error())
+		}
 	case *memorablelength != -1:
 		aliasProvider = memorable.New(&memorable.Config{
 			Length: *memorablelength,


### PR DESCRIPTION
Also switched to camelCase in the flag names (eg. `alphanumericLength`)