### PR TITLE
Add digitalocean spaces storage support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,40 @@
 
 
 [[projects]]
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/sts"
+  ]
+  revision = "f0872da8a448f8cb10f4f0c95c2100e4f7356448"
+  version = "v1.13.16"
+
+[[projects]]
   name = "github.com/boltdb/bolt"
   packages = ["."]
   revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
@@ -12,6 +46,12 @@
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "6333e38ac20b8949a8dd68baa3650f4dee8f39f0"
+  version = "v1.33.0"
 
 [[projects]]
   branch = "master"
@@ -34,6 +74,11 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -129,6 +174,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1504e02b67f490c0079a7f58e4a01a5f5d9a5107d75667e30bc16b36cdd35d42"
+  inputs-digest = "c314d4c7e7f7f823bfb9d57f4ee98ab05c26915cbad73bb1ec48f9d766b5db59"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,3 +44,7 @@
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.13.16"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ klein has three core components that are abstracted into "modules" to allow diff
      * Memorable—returns a configurable amount of English words
 3. storage
    * Handles storing and reading shortened URLs.
-   * Comes with three modules:
+   * Comes with four modules:
      * File—stores URL data as text files in a directory
      * Bolt—stores URL data in a [bolt](https://github.com/boltdb/bolt) database
      * Redis—stores URL data in a [redis](https://redis.io/) database (ensure you configure save)
+     * Spaces-stores URL data in DigitalOcean Spaces
 
 ## Usage
 
@@ -56,26 +57,31 @@ Usage:
   klein [flags]
 
 Flags:
-      --alias string                    what alias generation to use (alphanumeric, memorable) (default "alphanumeric")
-      --alias.alphanumeric.alpha        use letters in code (default true)
-      --alias.alphanumeric.length int   alphanumeric code length (default 5)
-      --alias.alphanumeric.num          use numbers in code (default true)
-      --alias.memorable.length int      memorable word count (default 3)
-      --auth string                     what auth backend to use (basic, key, none) (default "none")
-      --auth.basic.password string      password for HTTP basic auth
-      --auth.basic.username string      username for HTTP basic auth
-      --auth.key string                 upload API key
-  -h, --help                            help for klein
-      --listen string                   listen address (default "127.0.0.1:5556")
-      --root string                     root redirect
-      --storage string                  what storage backend to use (file, boltdb, redis) (default "file")
-      --storage.boltdb.path string      path to use for bolt db (default "bolt.db")
-      --storage.file.path string        path to use for file store (default "urls")
-      --storage.redis.address string    address:port of redis instance (default "127.0.0.1:6379")
-      --storage.redis.auth string       password to access redis
-      --storage.redis.db int            db to select within redis
-      --template string                 path to error template
-      --url string                      path to public facing url
+      --alias string                       what alias generation to use (alphanumeric, memorable) (default "alphanumeric")
+      --alias.alphanumeric.alpha           use letters in code (default true)
+      --alias.alphanumeric.length int      alphanumeric code length (default 5)
+      --alias.alphanumeric.num             use numbers in code (default true)
+      --alias.memorable.length int         memorable word count (default 3)
+      --auth string                        what auth backend to use (basic, key, none) (default "none")
+      --auth.basic.password string         password for HTTP basic auth
+      --auth.basic.username string         username for HTTP basic auth
+      --auth.key string                    upload API key
+  -h, --help                               help for klein
+      --listen string                      listen address (default "127.0.0.1:5556")
+      --root string                        root redirect
+      --storage string                     what storage backend to use (file, boltdb, redis, spaces) (default "file")
+      --storage.boltdb.path string         path to use for bolt db (default "bolt.db")
+      --storage.file.path string           path to use for file store (default "urls")
+      --storage.redis.address string       address:port of redis instance (default "127.0.0.1:6379")
+      --storage.redis.auth string          password to access redis
+      --storage.redis.db int               db to select within redis
+      --storage.spaces.access_key string   access key for spaces
+      --storage.spaces.path string         path of the file in spaces (default "klein.json")
+      --storage.spaces.region string       region for spaces
+      --storage.spaces.secret_key string   secret key for spaces
+      --storage.spaces.space string        space to use
+      --template string                    path to error template
+      --url string                         path to public facing url
 ```
 
 You can also use environment variables for configuration.

--- a/server/main.go
+++ b/server/main.go
@@ -83,7 +83,7 @@ func (b *Klein) redirect(w http.ResponseWriter, r *http.Request, alias string) {
 		return
 	}
 
-	http.Redirect(w, r, url, 301)
+	http.Redirect(w, r, url, 302)
 }
 
 func (b *Klein) create(w http.ResponseWriter, r *http.Request) {

--- a/storage/spaces/main.go
+++ b/storage/spaces/main.go
@@ -1,0 +1,132 @@
+package spaces
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/kamaln7/klein/alias"
+	"github.com/kamaln7/klein/storage"
+)
+
+// Provider implements an in memory storage that persists on DigitalOcean Spaces
+type Provider struct {
+	Config *Config
+	Spaces *s3.S3
+	URLs   map[string]string
+	mutex  sync.RWMutex
+}
+
+// Config contains the configuration for the file storage
+type Config struct {
+	AccessKey string
+	SecretKey string
+	Region    string
+	Space     string
+	Path      string
+
+	Alias alias.Provider
+}
+
+// ensure that the storage.Provider interface is implemented
+var _ storage.Provider = new(Provider)
+
+// New returns a new Provider instance
+func New(c *Config) (*Provider, error) {
+	spacesSession := session.New(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, ""),
+		Endpoint:    aws.String(fmt.Sprintf("https://%s.digitaloceanspaces.com", c.Region)),
+		Region:      aws.String("us-east-1"), // Needs to be us-east-1, or it'll fail.
+	})
+
+	spaces := s3.New(spacesSession)
+
+	object := s3.GetObjectInput{
+		Bucket: aws.String(c.Space),
+		Key:    aws.String(c.Path),
+	}
+
+	urls := make(map[string]string)
+
+	output, err := spaces.GetObject(&object)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+			return &Provider{
+				Spaces: spaces,
+				Config: c,
+				URLs:   urls,
+			}, nil
+		}
+
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(output.Body)
+
+	err = json.Unmarshal(buf.Bytes(), &urls)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		Spaces: spaces,
+		Config: c,
+		URLs:   urls,
+	}, nil
+}
+
+// Get attempts to find a URL by its alias and returns its original URL
+func (p *Provider) Get(alias string) (string, error) {
+	if url, exists := p.URLs[alias]; exists {
+		return url, nil
+	}
+
+	return "", storage.ErrNotFound
+}
+
+// Exists checks if there is a URL with the requested alias
+func (p *Provider) Exists(alias string) (bool, error) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	_, exists := p.URLs[alias]
+	return exists, nil
+}
+
+// Store creates a new short URL
+func (p *Provider) Store(url, alias string) error {
+	exists, _ := p.Exists(alias)
+	if exists {
+		return storage.ErrAlreadyExists
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.URLs[alias] = url
+
+	body, err := json.Marshal(p.URLs)
+	if err != nil {
+		return err
+	}
+
+	object := s3.PutObjectInput{
+		Body:   bytes.NewReader(body),
+		Bucket: aws.String(p.Config.Space),
+		Key:    aws.String(p.Config.Path),
+	}
+	_, err = p.Spaces.PutObject(&object)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a backend that stores the URLs in memory, and persists them to DigitalOcean Spaces.
It also changes the redirect code from 301 to 302, to avoid browsers permanently caching the redirect, and allowing for redirects to be changed.

This needs #11 and #12 to be merged first, as this is rebased on top of them.
I'll rebase this if needed when they are merged :)